### PR TITLE
Allow subsequent handlers have access to data of uploaded file(s)

### DIFF
--- a/_examples/main.go
+++ b/_examples/main.go
@@ -23,8 +23,27 @@ func main() {
 
 	mux := http.NewServeMux()
 
-	mux.Handle("/", handler.Upload("name")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle("/", handler.Upload("name", "lanre")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Println("Uploaded file")
+
+		f, err := gulter.FilesFromContext(r)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		ff, err := gulter.FileFromContext(r, "lanre")
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		fmt.Printf("%+v", ff)
+
+		for _, v := range f {
+			fmt.Printf("%+v", v)
+			fmt.Println()
+		}
 	})))
 
 	http.ListenAndServe(":3300", mux)

--- a/context.go
+++ b/context.go
@@ -29,6 +29,10 @@ func writeFilesToContext(ctx context.Context,
 		existingFiles = Files{}
 	}
 
+	for _, v := range f {
+		existingFiles[v.FieldName] = v
+	}
+
 	return context.WithValue(ctx, fileKey, existingFiles)
 }
 

--- a/context.go
+++ b/context.go
@@ -1,0 +1,63 @@
+package gulter
+
+import (
+	"context"
+	"net/http"
+)
+
+type contextKey string
+
+const (
+	fileKey contextKey = "files"
+)
+
+type errorMsg string
+
+func (e errorMsg) Error() string { return string(e) }
+
+const (
+	ErrNoFilesUploaded = errorMsg("gulter: no uploadable files found in request")
+)
+
+type Files map[string]File
+
+func writeFileToContext(ctx context.Context,
+	f File, formField string,
+) context.Context {
+	existingFiles, ok := ctx.Value(fileKey).(Files)
+	if !ok {
+		existingFiles = Files{}
+	}
+
+	existingFiles[formField] = f
+	return context.WithValue(ctx, fileKey, existingFiles)
+}
+
+// FilesFromContext returns all files that have been uploaded during the request
+func FilesFromContext(r *http.Request) (Files, error) {
+	files, ok := r.Context().Value(fileKey).(Files)
+	if !ok {
+		return nil, ErrNoFilesUploaded
+	}
+
+	return files, nil
+}
+
+// FileFromContext retrieves the uploaded file with
+// the given formfield value. This form field is what
+// was sent from the html/multipart form
+func FileFromContext(r *http.Request,
+	formField string,
+) (File, error) {
+	files, err := FilesFromContext(r)
+	if err != nil {
+		return File{}, err
+	}
+
+	f, ok := files[formField]
+	if !ok {
+		return File{}, ErrNoFilesUploaded
+	}
+
+	return f, nil
+}

--- a/context.go
+++ b/context.go
@@ -21,6 +21,17 @@ const (
 
 type Files map[string]File
 
+func writeFilesToContext(ctx context.Context,
+	f Files,
+) context.Context {
+	existingFiles, ok := ctx.Value(fileKey).(Files)
+	if !ok {
+		existingFiles = Files{}
+	}
+
+	return context.WithValue(ctx, fileKey, existingFiles)
+}
+
 func writeFileToContext(ctx context.Context,
 	f File, formField string,
 ) context.Context {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/adelowo/gulter
 
 go 1.21.7
+
+require golang.org/x/sync v0.6.0

--- a/handler.go
+++ b/handler.go
@@ -117,7 +117,7 @@ func (h *Gulter) Upload(keys ...string) func(next http.Handler) http.Handler {
 							UploadedFileName:  uploadedFileName,
 							FolderDestination: metadata.FolderDestination,
 							MimeType:          mimeType,
-							Size:              header.Size,
+							Size:              metadata.Size,
 						}
 						return nil
 					})

--- a/handler.go
+++ b/handler.go
@@ -6,6 +6,24 @@ import (
 	"net/http"
 )
 
+type File struct {
+	// FieldName denotes the field from the multipart form
+	FieldName string `json:"field_name,omitempty"`
+
+	// The name of the file from the client side
+	OriginalName string `json:"original_name,omitempty"`
+	// UploadedFileName denotes the name of the file when it was ultimately
+	// uploaded to the storage layer. The distinction is important because of
+	// potential changes to the file nmae that may be done
+	UploadedFileName string `json:"uploaded_file_name,omitempty"`
+	// FolderDestination is the folder that holds the uploaded file
+	FolderDestination string `json:"folder_destination,omitempty"`
+
+	MimeType string `json:"mime_type,omitempty"`
+
+	Size int64 `json:"size,omitempty"`
+}
+
 func Chain(handlers ...http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	})

--- a/storage.go
+++ b/storage.go
@@ -5,9 +5,17 @@ import (
 	"io"
 )
 
+type UploadFileOptions struct {
+	FileName string
+}
+
+type UploadedFileMetadata struct {
+	FolderDestination string
+}
+
 type Storage interface {
 	// Upload copies the reader to the backend file storage
 	// The name of the file is also provided.
-	Upload(context.Context, io.Reader, string) error
+	Upload(context.Context, io.Reader, *UploadFileOptions) (*UploadedFileMetadata, error)
 	io.Closer
 }

--- a/storage.go
+++ b/storage.go
@@ -10,7 +10,8 @@ type UploadFileOptions struct {
 }
 
 type UploadedFileMetadata struct {
-	FolderDestination string
+	FolderDestination string `json:"folder_destination"`
+	Size              int64  `json:"size"`
 }
 
 type Storage interface {

--- a/storage/disk.go
+++ b/storage/disk.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/adelowo/gulter"
 )
 
 type Disk struct {
@@ -14,14 +16,15 @@ type Disk struct {
 func (d *Disk) Close() error { return nil }
 
 func (d *Disk) Upload(ctx context.Context, r io.Reader,
-	fileName string,
-) error {
-	f, err := os.Create(filepath.Join(d.destinationFolder, fileName))
+	opts *gulter.UploadFileOptions,
+) (*gulter.File, error) {
+	f, err := os.Create(filepath.Join(d.destinationFolder,
+		opts.FileName))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer f.Close()
 
 	_, err = io.Copy(f, r)
-	return err
+	return nil, err
 }


### PR DESCRIPTION
The goal of this PR is to make it possible for subsequent handlers to have access to the files that have been uploaded.
this is important for storing the paths to these files alongside the database or something else in general.



```go

func main() {
	handler := gulter.New(
		gulter.WithDestination("/Users/lanreadelowo/yikes"),
		gulter.WithMaxFileSize(10<<20),
		gulter.WithNameFuncGenerator(func(s string) string {
			return "gulter-" + s
		}),
		gulter.WithValidationFunc(func(f multipart.File) error {
			return nil
		}),
		gulter.WithStorage(&storage.Disk{}))

	mux := http.NewServeMux()

	mux.Handle("/", handler.Upload("form_field1", "form_field2")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		fmt.Println("Uploaded file")

		f, err := gulter.FilesFromContext(r)
		if err != nil {
			fmt.Println(err)
			return
		}

		ff, err := gulter.FileFromContext(r, "lanre")
		if err != nil {
			fmt.Println(err)
			return
		}

		fmt.Printf("%+v", ff)

		for _, v := range f {
			fmt.Printf("%+v", v)
			fmt.Println()
		}
	})))

	http.ListenAndServe(":3300", mux)
}

```