### PR TITLE
allow for debug mode when using s3 storage

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -16,6 +16,10 @@ import (
 
 type S3Options struct {
 	Bucket string
+	// If true, this will log request and responses
+	DebugMode bool
+
+	UsePathStyle bool
 
 	// Only use if the bucket supports ACL
 	ACL types.ObjectCannedACL
@@ -31,8 +35,18 @@ func NewS3FromConfig(cfg aws.Config, opts S3Options) (*S3Store, error) {
 		return nil, errors.New("please provide a valid s3 bucket")
 	}
 
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if opts.UsePathStyle {
+			o.UsePathStyle = true
+		}
+
+		if opts.DebugMode {
+			o.ClientLogMode = aws.LogSigning | aws.LogRequest | aws.LogResponseWithBody
+		}
+	})
+
 	return &S3Store{
-		client: s3.NewFromConfig(cfg),
+		client: client,
 		opts:   opts,
 	}, nil
 }
@@ -47,8 +61,18 @@ func NewS3FromEnvironment(opts S3Options) (*S3Store, error) {
 		return nil, err
 	}
 
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if opts.UsePathStyle {
+			o.UsePathStyle = true
+		}
+
+		if opts.DebugMode {
+			o.ClientLogMode = aws.LogSigning | aws.LogRequest | aws.LogResponseWithBody
+		}
+	})
+
 	return &S3Store{
-		client: s3.NewFromConfig(cfg),
+		client: client,
 		opts:   opts,
 	}, nil
 }

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -36,9 +36,7 @@ func NewS3FromConfig(cfg aws.Config, opts S3Options) (*S3Store, error) {
 	}
 
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-		if opts.UsePathStyle {
-			o.UsePathStyle = true
-		}
+		o.UsePathStyle = opts.UsePathStyle
 
 		if opts.DebugMode {
 			o.ClientLogMode = aws.LogSigning | aws.LogRequest | aws.LogResponseWithBody
@@ -62,9 +60,7 @@ func NewS3FromEnvironment(opts S3Options) (*S3Store, error) {
 	}
 
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-		if opts.UsePathStyle {
-			o.UsePathStyle = true
-		}
+		o.UsePathStyle = opts.UsePathStyle
 
 		if opts.DebugMode {
 			o.ClientLogMode = aws.LogSigning | aws.LogRequest | aws.LogResponseWithBody


### PR DESCRIPTION
You can now choose to log request and responses to the S3 compatible store so you can debug failures or otherwise